### PR TITLE
Change driver from local to class variable

### DIFF
--- a/pdfy/pdfy.py
+++ b/pdfy/pdfy.py
@@ -28,7 +28,7 @@ class Pdfy():
         if executable_path:
             webdriver_params['executable_path'] = executable_path
 
-        driver = webdriver.Chrome(**webdriver_params)
+        self.driver = webdriver.Chrome(**webdriver_params)
         self.chrome = PyChromeDevTools.ChromeInterface(port=debug_port)
         self.chrome.Page.enable()
 


### PR DESCRIPTION
I think the driver should be an instance variables.  I need access to the driver so I can interact with the page before I convert it to a PDF.  Plus the __del__() needs this change I think